### PR TITLE
Round label values before voting

### DIFF
--- a/python/voxel_vote
+++ b/python/voxel_vote
@@ -45,7 +45,7 @@ if __name__ == "__main__":
             t.shape = (volhandles[0].sizes[1], volhandles[0].sizes[2])
             sliceArray[j::] = t
         
-        outfile.data[i::] = mode(sliceArray)[0]
+        outfile.data[i::] = mode(rint(sliceArray))[0]
 
     outfile.writeFile()
     outfile.closeVolume()


### PR DESCRIPTION
This handles the cases where labels are floats that are only near their int label value.

@gdevenyi mentioned to me there are changes in the minc-tools pipe for handling label values better?  In any case, we were recently bitten by float labels not voting correctly and this fixes that in a reasonable way (rounding seems to be what the other label-aware tools have been doing, afaik). 
